### PR TITLE
Fixed e2e test_movies_in_view by clearing movie repo database

### DIFF
--- a/tests/e2e/test_all_movies_page.py
+++ b/tests/e2e/test_all_movies_page.py
@@ -24,3 +24,4 @@ def test_movies_in_view(test_app: FlaskClient) -> None:
     data = response.data.decode()
     assert "dookie</td>" in data
     assert response.status_code == 200
+    movie_repository.clear_db()


### PR DESCRIPTION
## Changes
-Fixed the `test_movies_in_view` e2e test case by clearing the initial movie repository during testing. Used `.clear_db()` to clear the movie repository.
## Issue ticket number and link
Ticket 1 - Fulfilled by Brandon Hach

## Checklist before requesting a review
- [✓] I have performed a self-review of my code